### PR TITLE
Fix for elegant termination of queued auto-retry operations.

### DIFF
--- a/AFHTTPRequestOperationManager+AutoRetry.m
+++ b/AFHTTPRequestOperationManager+AutoRetry.m
@@ -108,6 +108,11 @@ SYNTHESIZE_ASC_OBJ(__retryDelayCalcBlock, setRetryDelayCalcBlock);
                                                 autoRetryOf:(int)retriesRemaining retryInterval:(int)intervalInSeconds {
 
     void (^retryBlock)(AFHTTPRequestOperation *, NSError *) = ^(AFHTTPRequestOperation *operation, NSError *error) {
+        // operation is cancelled, exit early
+        if (operation.isCancelled) {
+            return;
+        }
+
         // error is fatal, do not retry
         if ([self isErrorFatal:error]) {
             ARLog(@"AutoRetry: Request failed with error: %@", error.localizedDescription);


### PR DESCRIPTION
In the retry block, checks whether the operation has been cancelled and if so, immediately return.

Without this check & return, user code can't correctly cancel operations on an AFHTTPRequestOperationManager operationQueue. This appears to have the downstream effect of causing download failures, however the cancelling should be respected.
