### PR TITLE
Change import

### DIFF
--- a/AFHTTPSessionManager+AutoRetry.m
+++ b/AFHTTPSessionManager+AutoRetry.m
@@ -2,7 +2,7 @@
 // Created by Shai Ohev Zion on 1/23/14.
 // Copyright (c) 2014 shaioz. All rights reserved.
 
-#import <AFNetworking+AutoRetry/AFHTTPRequestOperationManager+AutoRetry.h>
+#import "AFHTTPRequestOperationManager+AutoRetry.h"
 #import "AFHTTPSessionManager+AutoRetry.h"
 #import "ObjcAssociatedObjectHelpers.h"
 


### PR DESCRIPTION
No need for `<>` when it's in the same library. For some reason having `<>` style imports broke my build.
